### PR TITLE
Updated wiki links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 * Press [ to remove a lure
 * Press ] to add a lure
 * Hold shift to add/remove 10 lures (works with both hotkeys and Cheat Sheet/HERO's Mod)
-* Craft fishing lines using a [String](https://terraria.fandom.com/wiki/Strings), a [Hook](https://terraria.fandom.com/wiki/Hook), and 5 metal bars when "Enable fishing lines" is on
+* Craft fishing lines using a [String](https://terraria.wiki.gg/wiki/Strings), a [Hook](https://terraria.wiki.gg/wiki/Hook), and 5 metal bars when "Enable fishing lines" is on
 
 Each accessory offers:
 | Fishing Line        | Total Lures |


### PR DESCRIPTION
Hi, the Terraria community have stopped contributing to Fandom, meaning the existing links will become outdated. As many links as possible should be changed to provide a single place to reference for information, and to not confuse search engines.

From terraria.fandom.com/wiki/Hook to terraria.wiki.gg/wiki/Hook

Thank you so much for implementing the change if you can. It really helps the wiki communities.